### PR TITLE
Allow workflow to pass from forked repo PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_PAT }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/biome.json
+++ b/biome.json
@@ -24,7 +24,7 @@
     }
   },
   "files": {
-    "ignore": ["python", "package.json", "viewer/package.json"]
+    "ignore": ["python", "**/package.json"]
   },
   "vcs": {
     "enabled": true,

--- a/biome.json
+++ b/biome.json
@@ -24,7 +24,7 @@
     }
   },
   "files": {
-    "ignore": ["python"]
+    "ignore": ["python", "package.json", "viewer/package.json"]
   },
   "vcs": {
     "enabled": true,


### PR DESCRIPTION
# Description

Removes requirement for elevated-permissions access token in test workflow to allow forked PR workflows to pass.

Ignore package.jsons for linting because automated linting is applied by pnpm which clashes with biome causing the workflow to fail.
