### PR TITLE
Maximum update depth exceeded

### DIFF
--- a/viewer/src/components/VizarrViewer.tsx
+++ b/viewer/src/components/VizarrViewer.tsx
@@ -153,18 +153,27 @@ function VizarrViewerComponent({
     }
   }, [initialViewState, setViewStateAtom]);
 
-  const viewStateAtomWithEffect: PrimitiveAtom<ViewState | null> = atom(
-    (get) => get(viewStateAtom),
-    (get, set, update) => {
-      const viewState = typeof update === "function" ? update(get(viewStateAtom)) : update;
-      if (viewState) {
-        onViewStateChange?.({
-          target: viewState.target,
-          zoom: viewState.zoom,
-        });
-        set(viewStateAtom, update);
-      }
-    },
+  // Ref keeps the latest callback accessible inside the atom.
+  const onViewStateChangeRef = React.useRef(onViewStateChange);
+  React.useLayoutEffect(() => {
+    onViewStateChangeRef.current = onViewStateChange;
+  }, [onViewStateChange]);
+
+  // Atom is created once on mount so its reference remains stable across renders.
+  const [viewStateAtomWithEffect] = React.useState<PrimitiveAtom<ViewState | null>>(() =>
+    atom(
+      (get) => get(viewStateAtom),
+      (get, set, update) => {
+        const viewState = typeof update === "function" ? update(get(viewStateAtom)) : update;
+        if (viewState) {
+          onViewStateChangeRef.current?.({
+            target: viewState.target,
+            zoom: viewState.zoom,
+          });
+          set(viewStateAtom, update);
+        }
+      },
+    ),
   );
 
   const [configs] = React.useState(


### PR DESCRIPTION
# Description

Fixes an infinite re-render loop in `VizarrViewerComponent` caused by creating a jotai atom inside the component function body. Because atoms are plain objects, a new instance was created on every render, causing `ViewStateContext.Provider` to receive a new value each render and invalidate all consumers. 

Fixes #101  
Related to #89, #95

## Type of change

- [x] 🐛 Bug fix (non-breaking change that resolves an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚡ Optimisation (non-breaking improvement to performance or efficiency)
- [ ] 🧩 Documentation (adds or improves documentation)
- [ ] 🧱 Maintenance (refactor, dependency update, CI/CD, etc.)
- [ ] 🔥 Breaking change (fix or feature that causes existing functionality to change)

## Checklist

- [x] All tests pass (eg. `npm test`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
- [ ] Documentation updated (if required)
